### PR TITLE
Support golangci-lint-version

### DIFF
--- a/github-actions.json
+++ b/github-actions.json
@@ -19,7 +19,8 @@
         "^\\.github/workflows/.+\\.ya?ml$"
       ],
       "matchStrings": [
-        "uses: golangci/golangci-lint-action@.+?\\s+with:\\s+version: (?<currentValue>.+)\\n"
+        "uses: golangci/golangci-lint-action@.+?\\s+with:\\s+version: (?<currentValue>.+)\\n",
+        "\\s+golangci-lint-version: (?<currentValue>.+)\\n"
       ],
       "depNameTemplate": "golangci/golangci-lint",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
To update `golangci-lint-version` of https://github.com/int128/kubebuilder-workflows/blob/139d80b4950b5502198eb3a17c4aad37435bc578/.github/workflows/go.yaml#L10-L13